### PR TITLE
Update TTA in train_net.py

### DIFF
--- a/projects/WSL/tools/train_net.py
+++ b/projects/WSL/tools/train_net.py
@@ -182,10 +182,7 @@ class Trainer(DefaultTrainer):
         # In the end of training, run an evaluation with TTA
         # Only support some R-CNN models.
         logger.info("Running inference with test-time augmentation ...")
-        if cfg.WSL.RPN.RPN_ON:
-            model = GeneralizedRCNNWithTTAUNION(cfg, model)
-        else:
-            model = GeneralizedRCNNWithTTAAVG(cfg, model)
+        model = GeneralizedRCNNWithTTAAVG(cfg, model)
         evaluators = [
             cls.build_evaluator(
                 cfg, name, output_folder=os.path.join(cfg.OUTPUT_DIR, "inference_TTA")


### PR DESCRIPTION
With pre-compute proposals, `RPN` and `GeneralizedRCNNWithTTAUNION` are not used now.
And `cfg.WSL.RPN.RPN_ON` is not in default config file.